### PR TITLE
Improve manifest debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - Categorises installed apps using predefined keyword lists
 - Detects presence of major social media apps (Facebook, Twitter, Instagram, Parler, TikTok)
 - Generates JSON reports containing device info and categorized apps
+- Performs static manifest analysis of installed APKs
 - Works on Windows, macOS and Linux (uses the bundled ADB if available)
 
 ## Project Layout

--- a/analysis/manifest/__init__.py
+++ b/analysis/manifest/__init__.py
@@ -1,0 +1,21 @@
+"""Static manifest analysis utilities."""
+
+print("[analysis.manifest] Package imported")
+
+from .apk_extractor import APKExtractor
+from .manifest_analyzer import ManifestAnalyzer
+from .component_scanner import ComponentScanner
+from .certificate_parser import CertificateParser
+from .cvss_scorer import CVSSScorer
+from .risk_classifier import RiskClassifier
+from .version_tracker import VersionTracker
+
+__all__ = [
+    "APKExtractor",
+    "ManifestAnalyzer",
+    "ComponentScanner",
+    "CertificateParser",
+    "CVSSScorer",
+    "RiskClassifier",
+    "VersionTracker",
+]

--- a/analysis/manifest/apk_extractor.py
+++ b/analysis/manifest/apk_extractor.py
@@ -1,0 +1,86 @@
+"""Pull APK files from a device and compute hashes."""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import os
+from typing import Dict, List
+
+from utils.adb_utils import run_adb
+
+
+class APKExtractor:
+    """Helper for pulling APKs from a device."""
+
+    def __init__(self,
+                 output_dir: str = "output/app_static_profiles",
+                 log_file: str = "output/apk_pull_log.csv") -> None:
+        self.output_dir = output_dir
+        self.log_file = log_file
+        os.makedirs(self.output_dir, exist_ok=True)
+        os.makedirs(os.path.dirname(self.log_file), exist_ok=True)
+        print(f"[APKExtractor] Output directory: {self.output_dir}")
+        print(f"[APKExtractor] Log file: {self.log_file}")
+
+    def _write_log(self, row: List[str]) -> None:
+        write_header = not os.path.exists(self.log_file)
+        with open(self.log_file, "a", newline="", encoding="utf-8") as f:
+            writer = csv.writer(f)
+            if write_header:
+                writer.writerow(["package", "remote_path", "local_path", "sha256"])
+                print(f"[APKExtractor] Writing header to log")
+            print(f"[APKExtractor] Logging row: {row}")
+            writer.writerow(row)
+
+    def pull_apk(self, serial: str, package: str) -> Dict[str, str] | None:
+        """Pull the APK for ``package`` from ``serial`` and return metadata."""
+        print(f"[APKExtractor] Pulling {package} from {serial}")
+        try:
+            result = run_adb(["-s", serial, "shell", "pm", "path", package])
+            for line in result.stdout.splitlines():
+                if line.startswith("package:"):
+                    remote_path = line.replace("package:", "").strip()
+                    break
+            else:
+                print(f"[APKExtractor] Failed to find path for {package}")
+                return None
+
+            pkg_dir = os.path.join(self.output_dir, package)
+            os.makedirs(pkg_dir, exist_ok=True)
+            local_path = os.path.join(pkg_dir, os.path.basename(remote_path))
+            print(f"[APKExtractor] Pulling from {remote_path} to {local_path}")
+            run_adb(["-s", serial, "pull", remote_path, local_path])
+
+            with open(local_path, "rb") as f:
+                sha256 = hashlib.sha256(f.read()).hexdigest()
+            print(f"[APKExtractor] SHA256 for {package}: {sha256}")
+
+            self._write_log([package, remote_path, local_path, sha256])
+            return {
+                "package": package,
+                "remote_path": remote_path,
+                "local_path": local_path,
+                "sha256": sha256,
+            }
+        except Exception as exc:
+            print(f"[APKExtractor] Error pulling {package}: {exc}")
+            return None
+
+    def pull_and_record(self, serial: str, package: str,
+                         analyzer: "ManifestAnalyzer" | None = None,
+                         tracker: "VersionTracker" | None = None) -> Dict[str, str] | None:
+        """Pull an APK and optionally record its version history."""
+        print(f"[APKExtractor] pull_and_record called for {package}")
+        meta = self.pull_apk(serial, package)
+        if not meta or not analyzer or not tracker:
+            return meta
+        manifest = analyzer.parse(meta["local_path"])
+        if manifest:
+            info = analyzer.get_package_info(manifest)
+            print(
+                f"[APKExtractor] Recording version {info.get('version_code', '')} "
+                f"for {package}"
+            )
+            tracker.record(package, info.get("version_code", ""), meta["sha256"])
+        return meta

--- a/analysis/manifest/certificate_parser.py
+++ b/analysis/manifest/certificate_parser.py
@@ -1,0 +1,26 @@
+"""Extract signing certificate details from an APK."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+import apkutils2
+
+
+class CertificateParser:
+    """Parse certificate information from APKs."""
+
+    def parse(self, apk_path: str) -> List[Dict[str, str]]:
+        """Return certificate subjects and MD5 digests."""
+        print(f"[CertificateParser] Parsing certificates from {apk_path}")
+        try:
+            apk = apkutils2.APK(apk_path)
+            certs = apk.get_certs() or []
+            results: List[Dict[str, str]] = []
+            for subject, md5 in certs:
+                results.append({"subject": subject, "md5": md5})
+            print(f"[CertificateParser] Found {len(results)} certificates")
+            return results
+        except Exception as exc:
+            print(f"[CertificateParser] Failed to parse certificates: {exc}")
+            return []

--- a/analysis/manifest/component_scanner.py
+++ b/analysis/manifest/component_scanner.py
@@ -1,0 +1,65 @@
+"""Identify exported components and risky permissions."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import apkutils2
+
+
+class ComponentScanner:
+    """Scan manifest data for potential risks."""
+
+    RISKY_PERMISSIONS = {
+        "android.permission.RECORD_AUDIO",
+        "android.permission.CAMERA",
+        "android.permission.READ_SMS",
+        "android.permission.SEND_SMS",
+        "android.permission.RECEIVE_SMS",
+        "android.permission.READ_CALL_LOG",
+        "android.permission.WRITE_CALL_LOG",
+        "android.permission.READ_CONTACTS",
+        "android.permission.WRITE_CONTACTS",
+        "android.permission.WRITE_SETTINGS",
+        "android.permission.REQUEST_INSTALL_PACKAGES",
+        "android.permission.SYSTEM_ALERT_WINDOW",
+    }
+
+    def scan(self, manifest: apkutils2.Manifest) -> Dict[str, Any]:
+        """Return exported components, intents and risky permissions."""
+        print("[ComponentScanner] Scanning manifest")
+        data = manifest.json() or {}
+        exported: List[Dict[str, str]] = []
+        intent_actions: List[str] = []
+        app = data.get("application", {})
+        for comp_type in ["activity", "provider", "receiver", "service"]:
+            comps = app.get(comp_type, [])
+            if isinstance(comps, dict):
+                comps = [comps]
+            for comp in comps:
+                exported_flag = comp.get("@android:exported") == "true"
+                name = comp.get("@android:name")
+                filters = comp.get("intent-filter", [])
+                if isinstance(filters, dict):
+                    filters = [filters]
+                actions = []
+                for flt in filters:
+                    acts = flt.get("action", [])
+                    if isinstance(acts, dict):
+                        acts = [acts]
+                    for a in acts:
+                        act_name = a.get("@android:name")
+                        if act_name:
+                            actions.append(act_name)
+                if exported_flag:
+                    exported.append({"type": comp_type, "name": name})
+                intent_actions.extend(actions)
+        perms = [p for p in manifest.permissions if p in self.RISKY_PERMISSIONS]
+        print(f"[ComponentScanner] Exported components: {exported}")
+        print(f"[ComponentScanner] Risky permissions: {perms}")
+        print(f"[ComponentScanner] Intent actions: {intent_actions}")
+        return {
+            "exported_components": exported,
+            "risky_permissions": perms,
+            "intent_actions": list(set(intent_actions)),
+        }

--- a/analysis/manifest/cvss_scorer.py
+++ b/analysis/manifest/cvss_scorer.py
@@ -1,0 +1,27 @@
+"""Simple CVSS-like scoring for mobile app risks."""
+
+from __future__ import annotations
+
+from typing import Dict, Any
+
+
+class CVSSScorer:
+    """Assign a crude severity score from component scan results."""
+
+    def score(self, scan_results: Dict[str, Any]) -> float:
+        """Return a score between 0.0 and 10.0."""
+        risky_perms = scan_results.get("risky_permissions", [])
+        exported = scan_results.get("exported_components", [])
+        actions = scan_results.get("intent_actions", [])
+        print(
+            f"[CVSSScorer] perms={len(risky_perms)} exported={len(exported)}"
+            f" actions={len(actions)}"
+        )
+        score = (
+            len(risky_perms) * 1.0
+            + len(exported) * 0.5
+            + len(actions) * 0.2
+        )
+        final = min(10.0, score)
+        print(f"[CVSSScorer] Score: {final}")
+        return final

--- a/analysis/manifest/manifest_analyzer.py
+++ b/analysis/manifest/manifest_analyzer.py
@@ -1,0 +1,73 @@
+"""Parse AndroidManifest.xml from an APK."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List
+
+import apkutils2
+
+
+class ManifestAnalyzer:
+    """Extract and parse manifest information."""
+
+    def parse(self, apk_path: str) -> apkutils2.Manifest | None:
+        """Return a ``Manifest`` object for ``apk_path`` if possible."""
+        if not os.path.isfile(apk_path):
+            print(f"[ManifestAnalyzer] APK not found: {apk_path}")
+            return None
+        try:
+            print(f"[ManifestAnalyzer] Parsing manifest from {apk_path}")
+            apk = apkutils2.APK(apk_path)
+            xml = apk.get_org_manifest()
+            if not xml:
+                print("[ManifestAnalyzer] get_org_manifest returned no data")
+                return None
+            return apkutils2.Manifest(xml)
+        except Exception as exc:
+            print(f"[ManifestAnalyzer] Error parsing manifest: {exc}")
+            return None
+
+    def to_dict(self, manifest: apkutils2.Manifest) -> Dict[str, Any]:
+        """Convert a Manifest object to a dictionary."""
+        try:
+            data = manifest.json() or {}
+            print(f"[ManifestAnalyzer] Manifest dictionary keys: {list(data.keys())}")
+            return data
+        except Exception as exc:
+            print(f"[ManifestAnalyzer] Failed to convert manifest to dict: {exc}")
+            return {}
+
+    def get_package_info(self, manifest: apkutils2.Manifest) -> Dict[str, str]:
+        """Return basic package metadata."""
+        info = {
+            "package": manifest.package_name or "",
+            "version_code": str(manifest.version_code or ""),
+            "version_name": manifest.version_name or "",
+            "main_activity": manifest.main_activity or "",
+        }
+        print(f"[ManifestAnalyzer] Package info: {info}")
+        return info
+
+    def get_permissions(self, manifest: apkutils2.Manifest) -> List[str]:
+        """Return all permissions requested by the app."""
+        try:
+            perms = list(manifest.permissions)
+            print(f"[ManifestAnalyzer] Permissions: {perms}")
+            return perms
+        except Exception as exc:
+            print(f"[ManifestAnalyzer] Failed to get permissions: {exc}")
+            return []
+
+    def get_sdk_info(self, manifest: apkutils2.Manifest) -> Dict[str, str]:
+        """Return ``minSdk`` and ``targetSdk`` levels if declared."""
+        data = self.to_dict(manifest)
+        uses_sdk = data.get("uses-sdk", {})
+        if isinstance(uses_sdk, list):
+            uses_sdk = uses_sdk[0] if uses_sdk else {}
+        info = {
+            "min_sdk": uses_sdk.get("@android:minSdkVersion", ""),
+            "target_sdk": uses_sdk.get("@android:targetSdkVersion", ""),
+        }
+        print(f"[ManifestAnalyzer] SDK info: {info}")
+        return info

--- a/analysis/manifest/risk_classifier.py
+++ b/analysis/manifest/risk_classifier.py
@@ -1,0 +1,18 @@
+"""Classify apps based on their CVSS score."""
+
+from __future__ import annotations
+
+
+class RiskClassifier:
+    """Simple LOW/MEDIUM/HIGH classifier."""
+
+    def classify(self, score: float) -> str:
+        print(f"[RiskClassifier] Classifying score: {score}")
+        if score >= 7.0:
+            level = "HIGH"
+        elif score >= 4.0:
+            level = "MEDIUM"
+        else:
+            level = "LOW"
+        print(f"[RiskClassifier] Level: {level}")
+        return level

--- a/analysis/manifest/version_tracker.py
+++ b/analysis/manifest/version_tracker.py
@@ -1,0 +1,49 @@
+"""Track version information for APKs over time."""
+
+from __future__ import annotations
+
+import csv
+import os
+from datetime import datetime
+from typing import List, Tuple
+
+
+class VersionTracker:
+    """Append version and hash details to a timeline CSV."""
+
+    def __init__(self, timeline_file: str = "output/update_timeline.csv") -> None:
+        self.timeline_file = timeline_file
+        os.makedirs(os.path.dirname(self.timeline_file), exist_ok=True)
+        print(f"[VersionTracker] Timeline file: {self.timeline_file}")
+
+    def record(self, package: str, version: str, sha256: str) -> None:
+        """Add an entry for the given package version."""
+        write_header = not os.path.exists(self.timeline_file)
+        with open(self.timeline_file, "a", newline="", encoding="utf-8") as f:
+            writer = csv.writer(f)
+            if write_header:
+                writer.writerow(["timestamp", "package", "version", "sha256"])
+                print("[VersionTracker] Writing header to timeline")
+            print(
+                f"[VersionTracker] Recording {package} version {version} sha256 {sha256}"
+            )
+            writer.writerow([
+                datetime.utcnow().isoformat(timespec="seconds"),
+                package,
+                version,
+                sha256,
+            ])
+
+    def history(self, package: str) -> List[Tuple[str, str, str, str]]:
+        """Return timeline rows for ``package``."""
+        if not os.path.exists(self.timeline_file):
+            return []
+        rows: List[Tuple[str, str, str, str]] = []
+        with open(self.timeline_file, newline="", encoding="utf-8") as f:
+            reader = csv.reader(f)
+            next(reader, None)  # skip header
+            for row in reader:
+                if len(row) == 4 and row[1] == package:
+                    rows.append(tuple(row))
+        print(f"[VersionTracker] History for {package}: {len(rows)} entries")
+        return rows


### PR DESCRIPTION
## Summary
- add debug output in manifest analysis modules
- print status during APK extraction, manifest parsing, scanning, certificate parsing, scoring and tracking

## Testing
- `python -m py_compile analysis/manifest/*.py`
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
from analysis.manifest import APKExtractor, ManifestAnalyzer, ComponentScanner, CertificateParser, CVSSScorer, RiskClassifier, VersionTracker
print('classes:', APKExtractor.__name__, ManifestAnalyzer.__name__, ComponentScanner.__name__, CertificateParser.__name__, CVSSScorer.__name__, RiskClassifier.__name__, VersionTracker.__name__)
PY`


------
https://chatgpt.com/codex/tasks/task_e_686404c6c964832791d5e36707b3985a