### PR TITLE
Add more debug prints to APK helpers

### DIFF
--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -1,1 +1,5 @@
 "Analysis modules for Nethira."
+
+from . import apps, device, manifests
+
+__all__ = ["apps", "device", "manifests"]

--- a/analysis/manifests/__init__.py
+++ b/analysis/manifests/__init__.py
@@ -1,0 +1,14 @@
+"Manifest analysis utilities." 
+
+from .manifest_info import (
+    get_manifest_bytes,
+    get_manifest_xml,
+    get_certificate_fingerprints,
+)
+
+__all__ = [
+    "get_manifest_bytes",
+    "get_manifest_xml",
+    "get_certificate_fingerprints",
+]
+

--- a/analysis/manifests/manifest_info.py
+++ b/analysis/manifests/manifest_info.py
@@ -1,0 +1,46 @@
+"""Functions for retrieving manifest and signing info from APKs."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from utils import apk_utils, hash_utils
+
+
+def get_manifest_bytes(apk_path: str) -> Optional[bytes]:
+    """Return the raw manifest bytes from the APK."""
+    print(f"[manifest_info] get_manifest_bytes: {apk_path}")
+    data = apk_utils.extract_manifest(apk_path)
+    if data:
+        print(f"[manifest_info] Retrieved {len(data)} bytes")
+    else:
+        print("[manifest_info] No manifest bytes found")
+    return data
+
+
+def get_manifest_xml(apk_path: str) -> Optional[str]:
+    """Return the decoded manifest XML string."""
+    print(f"[manifest_info] get_manifest_xml: {apk_path}")
+    xml = apk_utils.extract_manifest_xml(apk_path)
+    if xml:
+        print(f"[manifest_info] XML length: {len(xml)}")
+    else:
+        print("[manifest_info] XML not found")
+    return xml
+
+
+def get_certificate_fingerprints(apk_path: str) -> Dict[str, str]:
+    """Return SHA-256, SHA-1 and MD5 fingerprints for the APK certificate."""
+    print(f"[manifest_info] get_certificate_fingerprints: {apk_path}")
+    cert = apk_utils.extract_certificate(apk_path)
+    if not cert:
+        print("[manifest_info] Certificate not found")
+        return {}
+    fingerprints = {
+        "sha256": hash_utils.sha256_digest(cert),
+        "sha1": hash_utils.sha1_digest(cert),
+        "md5": hash_utils.md5_digest(cert),
+    }
+    print(f"[manifest_info] Fingerprints: {fingerprints}")
+    return fingerprints
+

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -8,6 +8,19 @@ from .adb_utils import (
     list_connected_devices,
 )
 from .file_utils import get_timestamped_log_path, save_text_to_file
+from .hash_utils import (
+    sha256_digest,
+    sha1_digest,
+    md5_digest,
+    sha256_of_file,
+    sha1_of_file,
+    md5_of_file,
+)
+from .apk_utils import (
+    extract_manifest,
+    extract_certificate,
+    extract_manifest_xml,
+)
 
 __all__ = [
     "get_adb_path",
@@ -17,4 +30,14 @@ __all__ = [
     "list_connected_devices",
     "get_timestamped_log_path",
     "save_text_to_file",
+    "sha256_digest",
+    "sha1_digest",
+    "md5_digest",
+    "sha256_of_file",
+    "sha1_of_file",
+    "md5_of_file",
+    "extract_manifest",
+    "extract_certificate",
+    "extract_manifest_xml",
 ]
+

--- a/utils/apk_utils.py
+++ b/utils/apk_utils.py
@@ -1,0 +1,70 @@
+"""Helpers for working with APK files."""
+
+from __future__ import annotations
+
+import os
+import zipfile
+from typing import Optional
+
+try:
+    from apkutils2 import AXML
+except Exception:  # pragma: no cover - apkutils2 may not be installed
+    AXML = None
+
+
+def extract_manifest(apk_path: str) -> Optional[bytes]:
+    """Return the raw AndroidManifest.xml from the APK or ``None`` if missing."""
+    print(f"[apk_utils] extract_manifest: {apk_path}")
+    if not os.path.isfile(apk_path):
+        print("[apk_utils] File not found")
+        return None
+    try:
+        with zipfile.ZipFile(apk_path, "r") as z:
+            with z.open("AndroidManifest.xml") as f:
+                data = f.read()
+                print(f"[apk_utils] Manifest size: {len(data)} bytes")
+                return data
+    except Exception as e:
+        print(f"[apk_utils] Failed to extract manifest: {e}")
+        return None
+
+
+def extract_certificate(apk_path: str) -> Optional[bytes]:
+    """Return the first certificate file from ``META-INF`` or ``None``."""
+    print(f"[apk_utils] extract_certificate: {apk_path}")
+    if not os.path.isfile(apk_path):
+        print("[apk_utils] File not found")
+        return None
+    try:
+        with zipfile.ZipFile(apk_path, "r") as z:
+            for name in z.namelist():
+                lower = name.lower()
+                if lower.startswith("meta-inf/") and lower.endswith((".rsa", ".dsa", ".ec")):
+                    with z.open(name) as f:
+                        data = f.read()
+                        print(f"[apk_utils] Certificate {name} size: {len(data)} bytes")
+                        return data
+    except Exception as e:
+        print(f"[apk_utils] Failed to extract certificate: {e}")
+        return None
+    print("[apk_utils] Certificate not found")
+    return None
+
+
+def extract_manifest_xml(apk_path: str) -> Optional[str]:
+    """Return the decoded manifest XML string or ``None`` if unavailable."""
+    print(f"[apk_utils] extract_manifest_xml: {apk_path}")
+    raw = extract_manifest(apk_path)
+    if not raw:
+        print("[apk_utils] No manifest bytes extracted")
+        return None
+    if AXML is None:
+        print("[apk_utils] apkutils2.AXML is unavailable")
+        return None
+    try:
+        xml = AXML(raw).get_xml()
+        print(f"[apk_utils] Decoded manifest XML length: {len(xml)}")
+        return xml
+    except Exception as e:
+        print(f"[apk_utils] Failed to decode manifest XML: {e}")
+        return None

--- a/utils/hash_utils.py
+++ b/utils/hash_utils.py
@@ -1,0 +1,79 @@
+"""Simple hashing helpers using common algorithms."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Generator
+
+
+_CHUNK_SIZE = 8192
+
+
+def _hash_data(data: bytes, algo: str) -> str:
+    print(f"[hash_utils] Hashing data using {algo}")
+    hasher = hashlib.new(algo)
+    hasher.update(data)
+    digest = hasher.hexdigest()
+    print(f"[hash_utils] Digest: {digest}")
+    return digest
+
+
+def sha256_digest(data: bytes) -> str:
+    """Return the SHA-256 hex digest for *data*."""
+    print("[hash_utils] sha256_digest")
+    return _hash_data(data, "sha256")
+
+
+def sha1_digest(data: bytes) -> str:
+    """Return the SHA-1 hex digest for *data*."""
+    print("[hash_utils] sha1_digest")
+    return _hash_data(data, "sha1")
+
+
+def md5_digest(data: bytes) -> str:
+    """Return the MD5 hex digest for *data*."""
+    print("[hash_utils] md5_digest")
+    return _hash_data(data, "md5")
+
+
+def _file_chunks(path: str, chunk_size: int = _CHUNK_SIZE) -> Generator[bytes, None, None]:
+    print(f"[hash_utils] Reading file in chunks: {path}")
+    with open(path, "rb") as f:
+        while True:
+            chunk = f.read(chunk_size)
+            if not chunk:
+                break
+            yield chunk
+
+
+def sha256_of_file(path: str) -> str:
+    """Return the SHA-256 hex digest for the contents of *path*."""
+    print(f"[hash_utils] sha256_of_file: {path}")
+    hasher = hashlib.sha256()
+    for chunk in _file_chunks(path):
+        hasher.update(chunk)
+    digest = hasher.hexdigest()
+    print(f"[hash_utils] SHA-256: {digest}")
+    return digest
+
+
+def sha1_of_file(path: str) -> str:
+    """Return the SHA-1 hex digest for the contents of *path*."""
+    print(f"[hash_utils] sha1_of_file: {path}")
+    hasher = hashlib.sha1()
+    for chunk in _file_chunks(path):
+        hasher.update(chunk)
+    digest = hasher.hexdigest()
+    print(f"[hash_utils] SHA-1: {digest}")
+    return digest
+
+
+def md5_of_file(path: str) -> str:
+    """Return the MD5 hex digest for the contents of *path*."""
+    print(f"[hash_utils] md5_of_file: {path}")
+    hasher = hashlib.md5()
+    for chunk in _file_chunks(path):
+        hasher.update(chunk)
+    digest = hasher.hexdigest()
+    print(f"[hash_utils] MD5: {digest}")
+    return digest


### PR DESCRIPTION
## Summary
- improve debug output in the APK utilities
- print digest information from hashing helpers
- log manifest retrieval and fingerprinting steps

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686404c76cac832799ca657ff75f2168