### PR TITLE
Improve manifest analysis workflow

### DIFF
--- a/analysis/manifest/__init__.py
+++ b/analysis/manifest/__init__.py
@@ -1,0 +1,14 @@
+# filename: analysis/manifest/__init__.py
+"""Manifest analysis utilities."""
+
+from .scanner import scan_packages
+from .report_writer import write_json_report, write_csv_report
+from .pipeline import analyze_packages, format_results
+
+__all__ = [
+    "scan_packages",
+    "write_json_report",
+    "write_csv_report",
+    "analyze_packages",
+    "format_results",
+]

--- a/analysis/manifest/pipeline.py
+++ b/analysis/manifest/pipeline.py
@@ -1,0 +1,37 @@
+# filename: analysis/manifest/pipeline.py
+"""High level manifest analysis workflow."""
+
+from __future__ import annotations
+
+from typing import List, Tuple, Dict
+
+from .scanner import scan_packages
+from .report_writer import write_json_report, write_csv_report
+
+
+def analyze_packages(serial: str, packages: List[str]) -> Tuple[str, str, List[Dict[str, List[str]]]]:
+    """Scan packages and output JSON and CSV reports.
+
+    Returns:
+        Tuple[str, str]: Paths to the JSON and CSV reports.
+    """
+    print(f"[DEBUG] Starting manifest scan on {serial} for {len(packages)} packages")
+    results = scan_packages(serial, packages)
+    print(f"[DEBUG] Finished scanning. Generating reports...")
+    json_path = write_json_report(results)
+    csv_path = write_csv_report(results)
+    print(f"[DEBUG] Reports written: JSON -> {json_path}, CSV -> {csv_path}")
+    return json_path, csv_path, results
+
+
+def format_results(results: List[Dict[str, List[str]]]) -> str:
+    """Return a readable summary of manifest scan results."""
+    lines = []
+    for item in results:
+        pkg = item.get("package", "")
+        suspicious = item.get("suspicious", [])
+        if suspicious:
+            lines.append(f"{pkg}: {', '.join(suspicious)}")
+        else:
+            lines.append(f"{pkg}: no suspicious permissions")
+    return "\n".join(lines)

--- a/analysis/manifest/report_writer.py
+++ b/analysis/manifest/report_writer.py
@@ -1,0 +1,40 @@
+# filename: analysis/manifest/report_writer.py
+"""Report writers for manifest scan results."""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+from typing import List, Dict
+
+from utils import file_utils
+
+
+def _get_path(prefix: str, ext: str) -> str:
+    base = file_utils.get_timestamped_log_path(prefix)
+    path = os.path.splitext(base)[0] + f".{ext}"
+    print(f"[DEBUG] Generated {ext.upper()} report path: {path}")
+    return path
+
+
+def write_json_report(results: List[Dict[str, List[str]]], prefix: str = "manifest") -> str:
+    """Write results to a JSON file and return the path."""
+    path = _get_path(prefix, "json")
+    file_utils.save_text_to_file(path, json.dumps(results, indent=2))
+    print(f"[DEBUG] JSON report saved to {path}")
+    return path
+
+
+def write_csv_report(results: List[Dict[str, List[str]]], prefix: str = "manifest") -> str:
+    """Write results to a CSV file and return the path."""
+    path = _get_path(prefix, "csv")
+    with open(path, "w", newline="", encoding="utf-8") as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerow(["package", "permissions", "suspicious"])
+        for item in results:
+            perms = ",".join(item.get("permissions", []))
+            suspicious = ",".join(item.get("suspicious", []))
+            writer.writerow([item.get("package", ""), perms, suspicious])
+    print(f"[DEBUG] CSV report saved to {path}")
+    return path

--- a/analysis/manifest/scanner.py
+++ b/analysis/manifest/scanner.py
@@ -1,0 +1,43 @@
+# filename: analysis/manifest/scanner.py
+"""Simple Android manifest scanner using ADB."""
+
+from __future__ import annotations
+
+import re
+from typing import List, Dict
+
+from utils import adb_shell
+
+# Basic list of high-risk permissions for demonstration
+SUSPICIOUS_KEYWORDS = [
+    "READ_SMS",
+    "SEND_SMS",
+    "RECEIVE_SMS",
+    "WRITE_SMS",
+    "READ_PHONE_STATE",
+    "WRITE_SETTINGS",
+    "SYSTEM_ALERT_WINDOW",
+]
+
+
+def scan_app(serial: str, package: str) -> Dict[str, List[str]]:
+    """Return permission info for a single package."""
+    print(f"[DEBUG] Scanning permissions for {package} on {serial}")
+    output = adb_shell(serial, f"dumpsys package {package}")
+    perms = sorted(set(re.findall(r"android.permission.[A-Z_\.]+", output)))
+    suspicious = [p for p in perms if any(key in p for key in SUSPICIOUS_KEYWORDS)]
+    return {
+        "package": package,
+        "permissions": perms,
+        "suspicious": suspicious,
+    }
+
+
+def scan_packages(serial: str, packages: List[str]) -> List[Dict[str, List[str]]]:
+    """Scan multiple packages on a device."""
+    print(f"[DEBUG] Beginning scan of {len(packages)} package(s)")
+    results = []
+    for pkg in packages:
+        results.append(scan_app(serial, pkg))
+    print("[DEBUG] Package scan complete")
+    return results


### PR DESCRIPTION
## Summary
- add module headers to new manifest analysis files
- enhance manifest pipeline with formatted summary output
- display scan summary in CLI
- add debug print statements to track scanning and report generation

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686404c89a5483279e8aa41a7ae987dc