### PR TITLE
Add more detailed unit tests

### DIFF
--- a/tests/test_apk_utils.py
+++ b/tests/test_apk_utils.py
@@ -1,0 +1,80 @@
+import zipfile
+from pathlib import Path
+from types import SimpleNamespace
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from utils import apk_utils
+
+
+def create_sample_apk(path: Path) -> None:
+    manifest_data = b"<manifest></manifest>"
+    cert_data = b"dummy-cert"
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr("AndroidManifest.xml", manifest_data)
+        z.writestr("META-INF/CERT.RSA", cert_data)
+
+
+def test_extract_manifest_and_certificate(tmp_path):
+    apk_path = tmp_path / "sample.apk"
+    create_sample_apk(apk_path)
+
+    manifest = apk_utils.extract_manifest(str(apk_path))
+    assert manifest == b"<manifest></manifest>"
+
+    cert = apk_utils.extract_certificate(str(apk_path))
+    assert cert == b"dummy-cert"
+
+
+def test_extract_manifest_xml(tmp_path, monkeypatch):
+    apk_path = tmp_path / "sample.apk"
+    create_sample_apk(apk_path)
+
+    class DummyAXML:
+        def __init__(self, data: bytes) -> None:
+            self.data = data
+
+        def get_xml(self) -> str:
+            return "<manifest></manifest>"
+
+    monkeypatch.setattr(apk_utils, "AXML", DummyAXML)
+    xml = apk_utils.extract_manifest_xml(str(apk_path))
+    assert xml == "<manifest></manifest>"
+
+
+def test_missing_files_return_none(tmp_path):
+    missing = tmp_path / "missing.apk"
+    assert apk_utils.extract_manifest(str(missing)) is None
+    assert apk_utils.extract_certificate(str(missing)) is None
+    assert apk_utils.extract_manifest_xml(str(missing)) is None
+
+
+def test_extract_certificate_not_present(tmp_path):
+    apk_path = tmp_path / "no_cert.apk"
+    with zipfile.ZipFile(apk_path, "w") as z:
+        z.writestr("AndroidManifest.xml", b"<manifest></manifest>")
+    assert apk_utils.extract_certificate(str(apk_path)) is None
+
+
+def test_extract_manifest_xml_no_axml(tmp_path, monkeypatch):
+    apk_path = tmp_path / "sample.apk"
+    create_sample_apk(apk_path)
+    monkeypatch.setattr(apk_utils, "AXML", None)
+    assert apk_utils.extract_manifest_xml(str(apk_path)) is None
+
+
+def test_extract_manifest_xml_decode_error(tmp_path, monkeypatch):
+    apk_path = tmp_path / "sample.apk"
+    create_sample_apk(apk_path)
+
+    class BrokenAXML:
+        def __init__(self, data: bytes) -> None:
+            pass
+
+        def get_xml(self) -> str:
+            raise ValueError("bad")
+
+    monkeypatch.setattr(apk_utils, "AXML", BrokenAXML)
+    assert apk_utils.extract_manifest_xml(str(apk_path)) is None
+

--- a/tests/test_hash_utils.py
+++ b/tests/test_hash_utils.py
@@ -1,0 +1,34 @@
+import hashlib
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from utils import hash_utils
+
+
+def test_hash_digests():
+    data = b"hello world"
+    assert hash_utils.sha256_digest(data) == hashlib.sha256(data).hexdigest()
+    assert hash_utils.sha1_digest(data) == hashlib.sha1(data).hexdigest()
+    assert hash_utils.md5_digest(data) == hashlib.md5(data).hexdigest()
+
+
+def test_file_hashes(tmp_path):
+    path = tmp_path / "sample.txt"
+    content = b"sample content"
+    path.write_bytes(content)
+
+    assert hash_utils.sha256_of_file(str(path)) == hashlib.sha256(content).hexdigest()
+    assert hash_utils.sha1_of_file(str(path)) == hashlib.sha1(content).hexdigest()
+    assert hash_utils.md5_of_file(str(path)) == hashlib.md5(content).hexdigest()
+
+
+def test_chunked_file_hash(tmp_path):
+    """Files larger than the default chunk size should still hash correctly."""
+    path = tmp_path / "big.bin"
+    data = b"a" * 10000  # larger than 8k default chunk
+    path.write_bytes(data)
+
+    assert hash_utils.sha256_of_file(str(path)) == hashlib.sha256(data).hexdigest()
+

--- a/tests/test_manifest_pipeline.py
+++ b/tests/test_manifest_pipeline.py
@@ -1,0 +1,98 @@
+from unittest.mock import patch
+import sys
+from pathlib import Path
+import importlib.util
+import types
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+def _load_module(name: str, path: Path, package: str):
+    spec = importlib.util.spec_from_file_location(f"{package}.{name}", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[f"{package}.{name}"] = module
+    spec.loader.exec_module(module)
+    return module
+
+sys.modules.setdefault("analysis", types.ModuleType("analysis"))
+manifest_pkg = types.ModuleType("analysis.manifest")
+manifest_pkg.__path__ = [str(ROOT / "analysis/manifest")]
+sys.modules.setdefault("analysis.manifest", manifest_pkg)
+sys.modules["analysis"].manifest = manifest_pkg
+
+pipeline = _load_module("pipeline", ROOT / "analysis/manifest/pipeline.py", "analysis.manifest")
+scanner = _load_module("scanner", ROOT / "analysis/manifest/scanner.py", "analysis.manifest")
+
+
+def test_format_results():
+    results = [
+        {"package": "com.example", "suspicious": ["READ_SMS"]},
+        {"package": "com.safe", "suspicious": []},
+    ]
+    output = pipeline.format_results(results).splitlines()
+    assert output[0] == "com.example: READ_SMS"
+    assert output[1] == "com.safe: no suspicious permissions"
+
+
+def test_scan_app_parses_permissions():
+    adb_output = """
+        package: com.example
+        permission: android.permission.READ_SMS
+        permission: android.permission.WRITE_CONTACTS
+    """
+    with patch("analysis.manifest.scanner.adb_shell", return_value=adb_output):
+        result = scanner.scan_app("serial", "com.example")
+    assert result["package"] == "com.example"
+    assert "android.permission.READ_SMS" in result["permissions"]
+    assert "android.permission.WRITE_CONTACTS" in result["permissions"]
+    assert "android.permission.READ_SMS" in result["suspicious"]
+    assert "android.permission.WRITE_CONTACTS" not in result["suspicious"]
+
+
+def test_scan_app_no_permissions():
+    with patch("analysis.manifest.scanner.adb_shell", return_value=""):
+        result = scanner.scan_app("serial", "pkg")
+    assert result == {"package": "pkg", "permissions": [], "suspicious": []}
+
+
+def test_scan_packages_calls_scan_app(monkeypatch):
+    calls = []
+
+    def fake_scan_app(serial: str, pkg: str):
+        calls.append(pkg)
+        return {"package": pkg, "permissions": [], "suspicious": []}
+
+    monkeypatch.setattr(scanner, "scan_app", fake_scan_app)
+    results = scanner.scan_packages("serial", ["a", "b"])
+
+    assert calls == ["a", "b"]
+    assert len(results) == 2
+
+
+def test_analyze_packages_pipeline(monkeypatch, tmp_path):
+    fake_results = [{"package": "pkg", "permissions": [], "suspicious": []}]
+
+    monkeypatch.setattr(pipeline, "scan_packages", lambda s, p: fake_results)
+    json_called = []
+    csv_called = []
+
+    def fake_json(results):
+        json_called.append(results)
+        return str(tmp_path / "out.json")
+
+    def fake_csv(results):
+        csv_called.append(results)
+        return str(tmp_path / "out.csv")
+
+    monkeypatch.setattr(pipeline, "write_json_report", fake_json)
+    monkeypatch.setattr(pipeline, "write_csv_report", fake_csv)
+
+    json_path, csv_path, results = pipeline.analyze_packages("serial", ["pkg"])
+
+    assert json_path.endswith("out.json")
+    assert csv_path.endswith("out.csv")
+    assert results == fake_results
+    assert json_called == [fake_results]
+    assert csv_called == [fake_results]
+


### PR DESCRIPTION
## Summary
- expand tests for `hash_utils` to cover chunked file hashing
- add additional `apk_utils` tests for missing files, absent certificates, and XML decoding errors
- increase coverage for manifest pipeline with extra scanner and pipeline tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686404c8f6c083279aa24e582c72f165